### PR TITLE
Update service provider to read the default config when not published

### DIFF
--- a/src/Providers/KlaviyoServiceProvider.php
+++ b/src/Providers/KlaviyoServiceProvider.php
@@ -16,6 +16,8 @@
             $this->publishes([
                 __DIR__ . "/../../config/klaviyo.php" => config_path("klaviyo.php")
             ], "config");
+            
+            $this->mergeConfigFrom(__DIR__.'/../../config/klaviyo.php', 'klaviyo');
         }
 
         /**


### PR DESCRIPTION
Thank you for your package!

Looks like that's in the current setup it doesn't read the default config, so I had to run `./artisan vendor:publish` to make it work